### PR TITLE
Adds support for Redis URIs

### DIFF
--- a/src/main/java/org/github/siahsang/redutils/RedUtilsLockImpl.java
+++ b/src/main/java/org/github/siahsang/redutils/RedUtilsLockImpl.java
@@ -1,5 +1,6 @@
 package org.github.siahsang.redutils;
 
+import java.net.URI;
 import org.github.siahsang.redutils.common.OperationCallBack;
 import org.github.siahsang.redutils.common.RedUtilsConfig;
 import org.github.siahsang.redutils.common.ThreadManager;
@@ -45,6 +46,13 @@ public class RedUtilsLockImpl implements RedUtilsLock {
 
     public RedUtilsLockImpl(final String hostAddress, final int port) {
         this(hostAddress, port, 0);
+    }
+
+    public RedUtilsLockImpl(URI uri) {
+        this(new RedUtilsConfig
+                .RedUtilsConfigBuilder()
+                .uri(uri)
+                .build());
     }
 
     /**

--- a/src/main/java/org/github/siahsang/redutils/RedUtilsLockImpl.java
+++ b/src/main/java/org/github/siahsang/redutils/RedUtilsLockImpl.java
@@ -48,6 +48,10 @@ public class RedUtilsLockImpl implements RedUtilsLock {
         this(hostAddress, port, 0);
     }
 
+    public RedUtilsLockImpl(String uri) {
+        this(URI.create(uri));
+    }
+
     public RedUtilsLockImpl(URI uri) {
         this(new RedUtilsConfig
                 .RedUtilsConfigBuilder()

--- a/src/main/java/org/github/siahsang/redutils/common/RedUtilsConfig.java
+++ b/src/main/java/org/github/siahsang/redutils/common/RedUtilsConfig.java
@@ -12,6 +12,8 @@ public class RedUtilsConfig {
 
     public static final int DEFAULT_PORT = 6379;
 
+    private static final String REDIS_URI_PREFIX = "redis://";
+
     private final int waitingTimeForReplicasMillis;
 
     private final int retryCountForSyncingWithReplicas;
@@ -160,7 +162,7 @@ public class RedUtilsConfig {
         }
 
         private URI parseUri() {
-            return uri != null ? uri : createUri(hostAddress + ":" + port);
+            return uri != null ? uri : createUri(REDIS_URI_PREFIX + hostAddress + ":" + port);
         }
     }
 }

--- a/src/main/java/org/github/siahsang/redutils/common/RedUtilsConfig.java
+++ b/src/main/java/org/github/siahsang/redutils/common/RedUtilsConfig.java
@@ -1,5 +1,8 @@
 package org.github.siahsang.redutils.common;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  * @author Javad Alimohammadi
  */
@@ -23,9 +26,7 @@ public class RedUtilsConfig {
 
     private final int replicaCount;
 
-    private final String hostAddress;
-
-    public final int port;
+    private final URI uri;
 
     private RedUtilsConfig(RedUtilsConfigBuilder redUtilsConfigBuilder) {
         this.waitingTimeForReplicasMillis = redUtilsConfigBuilder.waitingTimeForReplicasMillis;
@@ -35,9 +36,7 @@ public class RedUtilsConfig {
         this.lockMaxPoolSize = redUtilsConfigBuilder.maxPoolSize;
         this.unlockedMessagePattern = redUtilsConfigBuilder.redUtilsUnLockedMessage;
         this.replicaCount = redUtilsConfigBuilder.replicaCount;
-        this.hostAddress = redUtilsConfigBuilder.hostAddress;
-        this.port = redUtilsConfigBuilder.port;
-
+        this.uri = redUtilsConfigBuilder.parseUri();
     }
 
     public int getWaitingTimeForReplicasMillis() {
@@ -68,14 +67,9 @@ public class RedUtilsConfig {
         return replicaCount;
     }
 
-    public String getHostAddress() {
-        return hostAddress;
+    public URI getUri() {
+        return uri;
     }
-
-    public int getPort() {
-        return port;
-    }
-
 
     public static final class RedUtilsConfigBuilder {
         private int waitingTimeForReplicasMillis = 1000;
@@ -95,6 +89,8 @@ public class RedUtilsConfig {
         private String hostAddress = DEFAULT_HOST_ADDRESS;
 
         private int port = DEFAULT_PORT;
+
+        private URI uri = null;
 
         public RedUtilsConfig build() {
             return new RedUtilsConfig(this);
@@ -143,6 +139,28 @@ public class RedUtilsConfig {
         public RedUtilsConfigBuilder port(int port) {
             this.port = port;
             return this;
+        }
+
+        public RedUtilsConfigBuilder uri(URI uri) {
+            this.uri = uri;
+            return this;
+        }
+
+        public RedUtilsConfigBuilder uri(String uri) {
+            this.uri = createUri(uri);
+            return this;
+        }
+
+        private URI createUri(String uri) {
+            try {
+                return new URI(uri);
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        private URI parseUri() {
+            return uri != null ? uri : createUri(hostAddress + ":" + port);
         }
     }
 }

--- a/src/main/java/org/github/siahsang/redutils/common/RedUtilsConfig.java
+++ b/src/main/java/org/github/siahsang/redutils/common/RedUtilsConfig.java
@@ -149,20 +149,12 @@ public class RedUtilsConfig {
         }
 
         public RedUtilsConfigBuilder uri(String uri) {
-            this.uri = createUri(uri);
+            this.uri = URI.create(uri);
             return this;
         }
 
-        private URI createUri(String uri) {
-            try {
-                return new URI(uri);
-            } catch (URISyntaxException e) {
-                throw new IllegalArgumentException(e);
-            }
-        }
-
         private URI parseUri() {
-            return uri != null ? uri : createUri(REDIS_URI_PREFIX + hostAddress + ":" + port);
+            return uri != null ? uri : URI.create(REDIS_URI_PREFIX + hostAddress + ":" + port);
         }
     }
 }

--- a/src/main/java/org/github/siahsang/redutils/common/connection/JedisConnectionManager.java
+++ b/src/main/java/org/github/siahsang/redutils/common/connection/JedisConnectionManager.java
@@ -30,7 +30,6 @@ public class JedisConnectionManager implements ConnectionManager<Jedis> {
 
     private final Map<String, List<Jedis>> reservedConnections = new ConcurrentHashMap<>();
 
-
     private final JedisPool channelConnectionPool;
 
     public JedisConnectionManager(RedUtilsConfig redUtilsConfig) {
@@ -38,8 +37,7 @@ public class JedisConnectionManager implements ConnectionManager<Jedis> {
 
         GenericObjectPoolConfig<Jedis> lockPoolConfig = ConnectionPoolFactory.makePool(capacity.get());
         this.channelConnectionPool = new JedisPool(lockPoolConfig,
-                redUtilsConfig.getHostAddress(),
-                redUtilsConfig.getPort(),
+                redUtilsConfig.getUri(),
                 redUtilsConfig.getReadTimeOutMillis()
         );
     }

--- a/src/test/java/org/github/siahsang/redutils/RedUtilsLockImplTest.java
+++ b/src/test/java/org/github/siahsang/redutils/RedUtilsLockImplTest.java
@@ -344,6 +344,32 @@ class RedUtilsLockImplTest extends AbstractBaseTest {
     }
 
     @Test
+    void test_acquire_with_URI_WHEN_happy_path() throws Exception {
+        //************************
+        //          Given
+        //************************
+        RedUtilsLockImpl redUtilsLock = new RedUtilsLockImpl("redis://" + GENERAL_REDIS_ADDRESS.masterHostAddress + ":" + GENERAL_REDIS_ADDRESS.masterPort);
+        AtomicBoolean firstTryToGetLock = new AtomicBoolean(false);
+
+
+        //************************
+        //          WHEN
+        //************************
+        redUtilsLock.acquire("lock1", () -> {
+            sleepSeconds(2);
+            firstTryToGetLock.set(true);
+        });
+
+
+        //************************
+        //          THEN
+        //************************
+        Assertions.assertTrue(firstTryToGetLock.get());
+        Assertions.assertNull(getKey("lock1"));
+
+    }
+
+    @Test
     void test_acquire_get_lock_multiple_time() throws Exception {
         //************************
         //          Given


### PR DESCRIPTION
Hey!

First of all, thanks for developing and sharing this library, it is helping us out in using distributed locks :+1: 

I just updated your code so that it supports Redis URIs, namely in this format: `redis://myUser:myPassword@host:9178/`

Let me know if you agree with the changes or if you would do something differently to support these URIs.